### PR TITLE
支持虚拟实体 input_boolean 

### DIFF
--- a/custom_components/vivohomebridge/const.py
+++ b/custom_components/vivohomebridge/const.py
@@ -6,6 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 """
 
 from homeassistant.const import Platform
+from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
 
 DOMAIN = "vivohomebridge"
 VIVO_HA_BRIDGE_VERSION = "1.0.0"
@@ -123,4 +124,5 @@ VIVO_HA_PLATFORM_PK: dict = {
     Platform.SENSOR: VIVO_HA_PLATFORM_HUMIDITY_TEMPERATURE_PK,
     Platform.WATER_HEATER: VIVO_HA_PLATFORM_WATER_HEATER_PK,
     Platform.BINARY_SENSOR: VIVO_HA_PLATFORM_COMMON_SENSOR_PK,
+    INPUT_BOOLEAN_DOMAIN: VIVO_HA_PLATFORM_SWITCH_PK,
 }

--- a/custom_components/vivohomebridge/device_manager.py
+++ b/custom_components/vivohomebridge/device_manager.py
@@ -1945,24 +1945,14 @@ class DeviceManager:
                 model = ""
                 area = ""
                 entity_id = device[VIVO_DEVICE_ENTITY_ID_KEY]
-                entity_obj = er.async_get(self._bridge_entity.hass).async_get(entity_id)
                 device_name = device.get(ATTR_FRIENDLY_NAME, "")
-                if entity_obj is None or entity_obj.device_id is None:
-                    VLog.warning(
-                        _TAG,
-                        f"[set_config_devices][{reason}] {entity_id}:"
-                        f"entity_obj or entity_obj.device_id is None",
+                _device = Utils.get_device_of_entity(self._bridge_entity.hass, entity_id)
+                if _device is not None:
+                    manufacturer = _device.manufacturer or ""
+                    model = _device.model or ""
+                    device_name = self._generate_device_name_of_bridge(
+                        entity_id, device_name, _device
                     )
-                else:
-                    _device = dr.async_get(self._bridge_entity.hass).async_get(
-                        entity_obj.device_id
-                    )
-                    if _device is not None:
-                        manufacturer = _device.manufacturer or ""
-                        model = _device.model or ""
-                        device_name = self._generate_device_name_of_bridge(
-                            entity_id, device_name, _device
-                        )
                 if device_name is None:
                     device_name = entity_id
                 new_device = dev_reg.async_get_or_create(

--- a/custom_components/vivohomebridge/utils.py
+++ b/custom_components/vivohomebridge/utils.py
@@ -6,7 +6,7 @@
 """
 
 from homeassistant.const import CONF_UNIT_OF_MEASUREMENT
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, device_registry as dr
 from .const import VIVO_HA_KEY_WORLD_DEV_LOGIC_MAC, VIVO_DEVICE_NAME_CONFIG_KEY, \
     VIVO_DEVICE_ENTITY_ID_KEY, VIVO_HA_KEY_WORLD_DEV_ENTRY_ID, VIVO_DEVICE_NAME_FRIENDLY_KEY,VIVO_DEVICE_ID_KEY
 
@@ -124,3 +124,24 @@ class Utils:
                         return line.split(":")[1].strip()
         except Exception as e:
             return "Unknown"
+
+    @staticmethod
+    def get_device_of_entity(hass, entity_id: str):
+        entity_registry = er.async_get(hass)
+        entity_obj = entity_registry.async_get(entity_id)
+        if entity_obj is None:
+            return None
+        if entity_obj.device_id is None:
+            class MockVirtualDevice:
+                sw_version = "HA-Virtual-1.0"
+                hw_version = "Virtual"
+                manufacturer = "HomeAssistant"
+                serial_number = "N/A"
+                model = "Virtual Entity"
+                name = "Virtual Device"
+                name_by_user = None
+            return MockVirtualDevice()
+        
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get(entity_obj.device_id)
+        return device

--- a/custom_components/vivohomebridge/vbridge.py
+++ b/custom_components/vivohomebridge/vbridge.py
@@ -524,8 +524,9 @@ class VBridgeEntity:
         if _entity_obj is None:
             VLog.warning(_TAG,F"entity_id:{entity_id} _entity_obj is None")
             return None
-        if _entity_obj.device_id is None:
-            VLog.warning(_TAG,f"entity_id:{entity_id} device_id is None")
+        _device = Utils.get_device_of_entity(hass, entity_id)
+        if _device is None:
+            VLog.warning(_TAG, f"entity_id:{entity_id} device is None")
             return None
         if not _entity_obj.id:
             VLog.info(_TAG, f"[generate_device_name] {entity_id} no id")
@@ -544,9 +545,6 @@ class VBridgeEntity:
         else:
             _result = default_original_name
             
-        if _entity_obj is not None and _entity_obj.device_id:
-            _device_id = _entity_obj.device_id
-            _device = dr.async_get(hass).async_get(_device_id)
         if platform_name:
             _result += f" ({platform_name})"
         return _result
@@ -720,10 +718,7 @@ class VBridgeEntity:
 
     def _sub_dev_common_attributes_get(self, entity_id: str) -> dict | None:
         common_attributes = {}
-        entity_obj: er.RegistryEntry = er.async_get(self.hass).async_get(entity_id)
-        if entity_obj is None or entity_obj.device_id is None:
-            return common_attributes
-        device: dr.DeviceEntry = dr.async_get(self.hass).async_get(entity_obj.device_id)
+        device = Utils.get_device_of_entity(self.hass, entity_id)
         for item in VIVO_HA_COMMON_ATTR_LIST:
             if item == VIVO_HA_COMMOM_ATTR_SOFTVER:
                 if device.sw_version is not None and device.sw_version != "":

--- a/custom_components/vivohomebridge/vbridge.py
+++ b/custom_components/vivohomebridge/vbridge.py
@@ -11,6 +11,7 @@ import json
 import re
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.cover import CoverDeviceClass
+from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
 from homeassistant.components.media_player import MediaPlayerDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
@@ -80,6 +81,7 @@ VIVO_HA_PLATFORM_SUPPORT_LIST = [
     Platform.COVER,
     Platform.BINARY_SENSOR,
     Platform.SENSOR,
+    INPUT_BOOLEAN_DOMAIN,
 ]
 _TAG = "bridge"
 
@@ -801,6 +803,8 @@ class VBridgeEntity:
                 return
         elif domain == Platform.WATER_HEATER:
             attributes_map = self.water_heater_model.attributes_map
+        elif domain == INPUT_BOOLEAN_DOMAIN:
+            attributes_map = self.switch_model.attributes_map
         else:
             VLog.info(_TAG, f"not support {domain}")
             return

--- a/custom_components/vivohomebridge/vbridge.py
+++ b/custom_components/vivohomebridge/vbridge.py
@@ -269,6 +269,10 @@ class VBridgeEntity:
             if _current_attrs is not None and len(_current_attrs) != 0:
                 for attr_name, attr_value in _current_attrs.items():
                     current_attrs[attr_name] = attr_value
+        elif platform == INPUT_BOOLEAN_DOMAIN:
+            attributes_map = self.switch_model.attributes_map
+            if new_state.state != old_state.state:
+                current_attrs["power"] = new_state.state
         elif platform == Platform.BINARY_SENSOR or platform == Platform.SENSOR:
             attributes_maps = self.sensor_model.attributes_map
             device_class = state.attributes.get(ATTR_DEVICE_CLASS)
@@ -659,6 +663,8 @@ class VBridgeEntity:
             elif device_platform == Platform.WATER_HEATER:
                 attributes_map = self.water_heater_model.attributes_map
                 attributes["state"] = device_state.state
+            elif device_platform == INPUT_BOOLEAN_DOMAIN:
+                attributes_map = self.switch_model.attributes_map
             else:
                 VLog.info(_TAG, f"[flush] not support :{device_platform}")
                 return

--- a/custom_components/vivohomebridge/vmodel.py
+++ b/custom_components/vivohomebridge/vmodel.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.components.switch import (
     SwitchDeviceClass,
 )
+from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
 from .const import (
     VIVO_HA_PLATFORM_PK,
     VIVO_HA_PLATFORM_PKY_KEY,
@@ -118,6 +119,11 @@ class VModel:
                 self.hass, self.entity_id, self.entity_attributes
             )
             pky = VIVO_HA_SENSORS_PK.get(self.entity_attributes.get(ATTR_DEVICE_CLASS))
+        elif self.platform == INPUT_BOOLEAN_DOMAIN:
+            self.entity_model = VSwitchModel.model_get(
+                self.hass, self.entity_id, self.entity_attributes
+            )
+            pky = VIVO_HA_PLATFORM_SWITCH_PK
         else:
             VLog.error(_TAG, f"[init]platform:{self.platform} not support")
             return

--- a/custom_components/vivohomebridge/vmodel.py
+++ b/custom_components/vivohomebridge/vmodel.py
@@ -39,6 +39,7 @@ from .v_sensor_model import VSensorModel, VIVO_HA_SENSORS_PK
 from .v_switch_model import VSwitchModel
 from .v_tv_model import VTVModelUtils
 from .v_utils.vlog import VLog
+from .utils import Utils
 
 _TAG = "model"
 
@@ -53,10 +54,10 @@ class VModel:
         self.platform = entity_id.split(".")[0]
         self.entity_obj = er.async_get(hass).async_get(entity_id)
         self.model: dict = {}
-        if self.entity_obj is None or self.entity_obj.device_id is None:
-            VLog.error(_TAG, f"{entity_id}:entity_obj or entity_obj.device_id is None")
+        if self.entity_obj is None:
+            VLog.error(_TAG, f"{entity_id}:entity_obj is None")
             return
-        self.device = dr.async_get(hass).async_get(self.entity_obj.device_id)
+        self.device = Utils.get_device_of_entity(hass, entity_id)
         self.state = self.hass.states.get(entity_id)
         if self.state is None:
             self.entity_attributes = {}
@@ -69,11 +70,11 @@ class VModel:
         self.entity_model: list = []
         pky = VIVO_HA_PLATFORM_PK.get(self.platform)
         manufacturer_name: str = "万物互联有限公司"
-        self.phyMac: str = self.entity_obj.device_id
         if not self.entity_obj.id:
             self.logicMac = None
         else:
             self.logicMac: str = f"{self.entity_obj.id}.{self.platform}"
+        self.phyMac: str = self.entity_obj.device_id if self.entity_obj.device_id is not None else self.logicMac
         if self.platform == Platform.LIGHT:
             self.entity_model = VLightModel.model_get(
                 self.hass, self.entity_id, self.entity_attributes


### PR DESCRIPTION
### 概述

增加了对HomeAssistant 辅助元素`input_boolean`的支持，将之作为`switch`类型同步到 VIVO 平台。

### 改动说明

1. **修改设备获取方法 (`Utils.get_device_of_entity`)**
   - 将设备查找逻辑抽取为统一的工具方法
   - 当实体没有关联物理设备（`device_id` 为 `None`）时，返回一个包含默认属性的 `MockVirtualDevice`，以支持虚拟实体无设备信息

2. **添加 `input_boolean` 辅助元素支持**
   - 将 `input_boolean` 平台映射为 switch 类型 PK（`VIVO_HA_PLATFORM_SWITCH_PK`）
   - 复用 `VSwitchModel` 进行状态映射和控制（turn_on / turn_off）
   - 使用 HA 官方常量 `homeassistant.components.input_boolean.DOMAIN`
   - 在 `async_handle_entity_state_change`、`flush_device_status`、`_v2h_states_set` 三个方法中添加`input_boolean`的控制与状态双向同步

3. 仅`input_boolean`能与`switch` 完全对应上，其他虚拟实体暂时不了解vivo平台有何实体可直接对应，故暂未支持
### 涉及文件

| 文件 | 改动 |
|------|--------|
| `utils.py` | 新增 `get_device_of_entity()` 静态方法 |
| `vmodel.py` | 移除 `device_id is None` 拦截，使用统一设备获取方法，新增 `input_boolean` 模型分支 |
| `vbridge.py` | `generate_device_name`、`_sub_dev_common_attributes_get` 使用统一设备获取；在支持列表、控制分支、状态变化推送、设备首次刷新四个位置添加 `input_boolean` 分支 |
| `device_manager.py` | `set_config_devices` 使用统一设备获取方法 |
| `const.py` | 新增 `input_boolean` domain 导入和 PK 映射 |